### PR TITLE
Dataset unified + Baselines + Single evaluation file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /pytorch3d
 *.pth
 *.npy
+test.csv

--- a/README.md
+++ b/README.md
@@ -221,6 +221,17 @@ python -m pytorch_fid  ./results/test_offline/fid/real  ./results/test_offline/f
 </p>
 </details>
 
+<details><summary> <b> Other baselines </b>  </summary>
+<p>
+ 
+- Run the following script to sequentially evaluate the naive baselines presented in the paper:
+ ```shell
+ python run_baselines.py --split SPLIT
+ ```
+ SPLIT can be `val` or `test`.
+</p>
+</details>
+
 
 
 ## 🖊️ Citation

--- a/README.md
+++ b/README.md
@@ -171,13 +171,13 @@ Then, we use a 3D-to-2D tool [PIRender](https://github.com/RenYurui/PIRender) to
 - Then, evaluate a trained model on val set and run:
 
  ```shell
-python val.py  --resume ./results/train_offline/best_checkpoint.pth  --gpu-ids 1  --outdir results/val_offline
+python evaluate.py  --resume ./results/train_offline/best_checkpoint.pth  --gpu-ids 1  --outdir results/val_offline --split val
 ```
  
 &nbsp; or
  
 ```shell
-python val.py  --resume ./results/train_online/best_checkpoint.pth  --gpu-ids 1  --online --outdir results/val_online 
+python evaluate.py  --resume ./results/train_online/best_checkpoint.pth  --gpu-ids 1  --online --outdir results/val_online --split val
 ```
  
 - For computing FID (FRRea), run the following script:
@@ -204,13 +204,13 @@ python -m pytorch_fid  ./results/val_offline/fid/real  ./results/val_offline/fid
 - Then, evaluate a trained model on val set and run:
 
  ```shell
-python test.py  --resume ./results/train_offline/best_checkpoint.pth  --gpu-ids 1  --outdir results/test_offline
+python evaluate.py  --resume ./results/train_offline/best_checkpoint.pth  --gpu-ids 1  --outdir results/test_offline --split test
 ```
  
 &nbsp; or
  
 ```shell
-python test.py  --resume ./results/train_online/best_checkpoint.pth  --gpu-ids 1  --online --outdir results/test_online 
+python evaluate.py  --resume ./results/train_online/best_checkpoint.pth  --gpu-ids 1  --online --outdir results/test_online --split test
 ```
  
 - For computing FID (FRRea), run the following script:

--- a/evaluate.py
+++ b/evaluate.py
@@ -1,0 +1,141 @@
+import os
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader
+import torch.optim as optim
+import argparse
+from tqdm import tqdm
+import logging
+from dataset import ReactionDataset
+from model import TransformerVAE
+from utils import AverageMeter
+from render import Render
+from model.losses import VAELoss
+from metric import *
+from dataset import get_dataloader
+
+def parse_arg():
+    parser = argparse.ArgumentParser(description='PyTorch Training')
+    # Param
+    parser.add_argument('--dataset-path', default="./data", type=str, help="dataset path")
+    parser.add_argument('--split', type=str, help="split of dataset", choices=["val", "test"], required=True)
+    parser.add_argument('--resume', default="", type=str, help="checkpoint path")
+    parser.add_argument('-b', '--batch-size', default=4, type=int, metavar='N', help='mini-batch size (default: 4)')
+    parser.add_argument('-j', '--num_workers', default=8, type=int, metavar='N',
+                        help='number of data loading workers (default: 8)')
+    parser.add_argument('--img-size', default=256, type=int, help="size of train/test image data")
+    parser.add_argument('--crop-size', default=224, type=int, help="crop size of train/test image data")
+    parser.add_argument('-seq-len', default=751, type=int, help="length of clip")
+    parser.add_argument('--window-size', default=8, type=int, help="prediction window-size for online mode")
+    parser.add_argument('--feature-dim', default=128, type=int, help="feature dim of model")
+    parser.add_argument('--audio-dim', default=39, type=int, help="feature dim of audio")
+    parser.add_argument('--_3dmm-dim', default=58, type=int, help="feature dim of 3dmm")
+    parser.add_argument('--emotion-dim', default=25, type=int, help="feature dim of emotion")
+    parser.add_argument('--online', action='store_true', help='online / offline method')
+    parser.add_argument('--outdir', default="./results", type=str, help="result dir")
+    parser.add_argument('--device', default='cuda', type=str, help="device: cuda / cpu")
+    parser.add_argument('--gpu-ids', type=str, default='0', help='gpu ids: e.g. 0  0,1,2, 0,2. use -1 for CPU')
+    parser.add_argument('--kl-p', default=0.0002, type=float, help="hyperparameter for kl-loss")
+
+    args = parser.parse_args()
+    return args
+
+
+# Train
+def val(args, model, val_loader, criterion, render):
+    losses = AverageMeter()
+    rec_losses = AverageMeter()
+    kld_losses = AverageMeter()
+    model.eval()
+
+    out_dir = os.path.join(args.outdir, args.split)
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+
+    listener_emotion_list = []
+    speaker_emotion_list = []
+    all_listener_emotion_list = []
+
+    for batch_idx, (speaker_video_clip, speaker_audio_clip, speaker_emotion, listener_video_clip, _, listener_emotion, listener_3dmm, listener_references) in enumerate(tqdm(val_loader)):
+        if torch.cuda.is_available():
+            speaker_video_clip, speaker_audio_clip, listener_emotion, listener_3dmm, listener_references = \
+                speaker_video_clip[:,:750].cuda(), speaker_audio_clip[:,:750].cuda(), listener_emotion[:,:750].cuda(), listener_3dmm[:,:750].cuda(), listener_references[:,:750].cuda()
+
+        with torch.no_grad():
+            listener_3dmm_out, listener_emotion_out, distribution = model(speaker_video_clip, speaker_audio_clip)
+
+            loss, rec_loss, kld_loss = criterion(listener_emotion, listener_3dmm, listener_emotion_out, listener_3dmm_out, distribution)
+
+            losses.update(loss.data.item(), speaker_video_clip.size(0))
+            rec_losses.update(rec_loss.data.item(), speaker_video_clip.size(0))
+            kld_losses.update(kld_loss.data.item(), speaker_video_clip.size(0))
+            B = speaker_video_clip.shape[0]
+            if (batch_idx % 25) == 0:
+                for bs in range(B):
+                    render.rendering_for_fid(out_dir, "{}_b{}_ind{}".format(args.split, str(batch_idx + 1), str(bs + 1)),
+                            listener_3dmm_out[bs], speaker_video_clip[bs], listener_references[bs], listener_video_clip[bs,:750])
+            listener_emotion_list.append(listener_emotion_out.cpu())
+            speaker_emotion_list.append(speaker_emotion)
+
+    listener_emotion = torch.cat(listener_emotion_list, dim = 0)
+    speaker_emotion = torch.cat(speaker_emotion_list, dim = 0)
+    all_listener_emotion_list.append(listener_emotion.unsqueeze(1))
+
+    print("-----------------Repeat 9 times-----------------")
+    for i in range(9):
+        listener_emotion_list = []
+        for batch_idx, (speaker_video_clip, speaker_audio_clip, _, _, _, _, _, _) in enumerate(tqdm(val_loader)):
+            if torch.cuda.is_available():
+                speaker_video_clip, speaker_audio_clip = \
+                    speaker_video_clip[:,:750].cuda(), speaker_audio_clip[:,:750].cuda()
+            with torch.no_grad():
+                _, listener_emotion_outs, _ = model(speaker_video_clip, speaker_audio_clip)
+                listener_emotion_list.append(listener_emotion_outs[:,:750].cpu())
+        listener_emotion = torch.cat(listener_emotion_list, dim=0)
+        all_listener_emotion_list.append(listener_emotion.unsqueeze(1))
+    all_listener_emotion = torch.cat(all_listener_emotion_list, dim=1)
+
+    print("-----------------Evaluating Metric-----------------")
+    FRC = compute_FRC_mp(args, all_listener_emotion, listener_emotion)
+    FRD = compute_FRD_mp(args, all_listener_emotion, listener_emotion)
+    FRDvs = compute_FRDvs(all_listener_emotion)
+    FRVar  = compute_FRVar(all_listener_emotion)
+    smse  = compute_s_mse(all_listener_emotion)
+    TLCC = compute_TLCC(all_listener_emotion, speaker_emotion)
+
+    return losses.avg, rec_losses.avg, kld_losses.avg, FRC, FRD, FRDvs, FRVar, smse, TLCC
+
+
+def main(args):
+    val_loader = get_dataloader(args, args.split)
+    model = TransformerVAE(img_size = args.img_size, audio_dim = args.audio_dim, output_emotion_dim = args.emotion_dim, output_3dmm_dim = args._3dmm_dim, feature_dim = args.feature_dim, seq_len = args.seq_len, online = args.online, window_size = args.window_size, device = args.device)
+    criterion = VAELoss(args.kl_p)
+
+    if args.resume != '':
+        checkpoint_path = args.resume
+        print("Resume from {}".format(checkpoint_path))
+        checkpoints = torch.load(checkpoint_path, map_location=torch.device('cpu'))
+        state_dict = checkpoints['state_dict']
+        model.load_state_dict(state_dict)
+
+    if torch.cuda.is_available():
+        model = model.cuda()
+        render = Render('cuda')
+    else:
+        render = Render()
+
+    val_loss, rec_loss, kld_loss, FRC, FRD, FRDvs, FRVar, smse, TLCC = val(args, model, val_loader, criterion, render)
+    print("{}_loss: {:.5f}   {}_rec_loss: {:.5f}  {}_kld_loss: {:.5f} ".format(args.split, val_loss, args.split, rec_loss, args.split, kld_loss))
+    print("Metric: | FRC: {:.5f}| FRD: {:.5f}| FRDvs: {:.5f}| FRVar: {:.5f}| S-MSE: {:.5f}| TLCC: {:.5f}".format(FRC, FRD, FRDvs, FRVar, smse, TLCC))
+
+
+# ---------------------------------------------------------------------------------
+
+
+if __name__=="__main__":
+    args = parse_arg()
+    os.environ["NUMEXPR_MAX_THREADS"] = '16'
+    os.environ["CUDA_VISIBLE_DEVICES"] = args.gpu_ids
+    main(args)
+

--- a/metric/FRC.py
+++ b/metric/FRC.py
@@ -6,6 +6,8 @@ import pandas as pd
 import os
 from tslearn.metrics import dtw
 import torch
+from functools import partial
+import multiprocessing as mp
 
 
 def concordance_correlation_coefficient(y_true, y_pred,

--- a/run_baselines.py
+++ b/run_baselines.py
@@ -110,7 +110,7 @@ def val(cfg):
                                                                                               TLCC))
 
         # latex friendly. FRC, FRD, TLCC with 2 decimals, FRDvs, FRVar, smse with 4 decimals. Split by columns in a table
-        print("B\\_{} & {:.2f} & {:.2f} & {:.4f} & {:.4f} & {:.4f} & - & {:.2f} \\\\".format(baseline, FRC, FRD, smse, FRVar, FRDvs, TLCC))
+        print("Latex-friendly --> B\\_{} & {:.2f} & {:.2f} & {:.4f} & {:.4f} & {:.4f} & - & {:.2f} \\\\".format(baseline, FRC, FRD, smse, FRVar, FRDvs, TLCC))
 
 
 def main():

--- a/run_baselines.py
+++ b/run_baselines.py
@@ -36,7 +36,7 @@ def get_baseline(cfg, baseline, num_pred=10, speaker_emotion=None, listener_emot
         # This baseline predicts the sequence/frame mean of the training data for each emotion dimension.
         global training_mean, training_mean_single
         if training_mean is None or training_mean_single is None:
-            train_loader = get_dataloader(cfg, "train", load_audio=False, load_video=False, load_3dmm=False, load_ref=False)
+            train_loader = get_dataloader(cfg, "train", load_audio=False, load_video_s=False, load_video_l=False, load_3dmm=False, load_ref=False)
             train_loader._split = "val" # to avoid data augmentation
             all_tr_emotion_list = []
             for batch_idx, (_, _, speaker_emotion, _, _, listener_emotion, _, _) in enumerate(tqdm(train_loader)):
@@ -68,7 +68,7 @@ def get_baseline(cfg, baseline, num_pred=10, speaker_emotion=None, listener_emot
 # Train
 def val(cfg):
     assert cfg.split in ["val", "test"], "split must be in [val, test]"
-    dataloader = get_dataloader(cfg, cfg.split, load_audio=False, load_video=False, load_3dmm=False, load_ref=False)
+    dataloader = get_dataloader(cfg, cfg.split, load_audio=False, load_video_s=False, load_video_l=False, load_3dmm=False, load_ref=False)
 
     for i, baseline in enumerate(baselines):
 

--- a/run_baselines.py
+++ b/run_baselines.py
@@ -1,0 +1,126 @@
+import numpy as np
+import torch
+import argparse
+from tqdm import tqdm
+from dataset import get_dataloader
+from metric import *
+import multiprocessing as mp
+
+baselines = ["GT",
+             "Random", "Mime",
+             "MeanSeq", "MeanFr", ]
+training_mean = None
+trainin_mean_single = None
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Running baselines')
+    # Param
+    parser.add_argument('--dataset-path', default="./data", type=str, help="dataset path")
+    parser.add_argument('--split', default="val", type=str, help="split of dataset", choices=["val", "test"])
+    parser.add_argument('-b', '--batch-size', default=4, type=int, metavar='N', help='mini-batch size (default: 4)')
+    parser.add_argument('-j', '--num_workers', default=8, type=int, metavar='N',
+                        help='number of data loading workers (default: 8)')
+    parser.add_argument('--weight-decay', '-wd', default=5e-4, type=float, metavar='W',
+                        help='weight decay (default: 1e-4)')
+    parser.add_argument('--img-size', default=256, type=int, help="size of train/test image data")
+    parser.add_argument('--crop-size', default=224, type=int, help="crop size of train/test image data")
+    parser.add_argument('-seq-len', default=751, type=int, help="length of clip")
+
+    args = parser.parse_args()
+    return args
+
+
+def get_baseline(cfg, baseline, num_pred=10, speaker_emotion=None, listener_emotion=None):
+    batch_size = speaker_emotion.shape[0]
+    if baseline == "MeanSeq" or baseline == "MeanFr":
+        # This baseline predicts the sequence/frame mean of the training data for each emotion dimension.
+        global training_mean, training_mean_single
+        if training_mean is None or training_mean_single is None:
+            train_loader = get_dataloader(cfg, "train", load_audio=False, load_video=False, load_3dmm=False, load_ref=False)
+            train_loader._split = "val" # to avoid data augmentation
+            all_tr_emotion_list = []
+            for batch_idx, (_, _, speaker_emotion, _, _, listener_emotion, _, _) in enumerate(tqdm(train_loader)):
+                all_tr_emotion_list.append(speaker_emotion.cpu())
+                all_tr_emotion_list.append(listener_emotion.cpu())
+            
+            all_tr_emotion = torch.cat(all_tr_emotion_list, dim = 0)
+            # average over all training data
+            all_tr_emotion = all_tr_emotion.mean(dim=0)
+            single_tr_emotion = all_tr_emotion.mean(dim=0)
+            # repeat to match the number of predictions
+            training_mean = all_tr_emotion[None, None, ...].repeat(batch_size, num_pred, 1, 1)
+            training_mean_single = single_tr_emotion[None, None, ...].repeat(batch_size, num_pred, training_mean.shape[2], 1)
+
+        return training_mean[:batch_size] if baseline == "MeanSeq" else training_mean_single[:batch_size]
+    elif baseline == "Random":
+        # predict listener emotion as random values between 0 and 1
+        return torch.rand(batch_size, num_pred, *speaker_emotion.shape[1:])
+    elif baseline == "Mime":
+        # predict listener emotion as speaker emotion (mime)
+        return speaker_emotion[:, None, ...].repeat(1, num_pred, 1, 1)
+    elif baseline == "GT":
+        # predict listener emotion as ground truth
+        return listener_emotion[:, None, ...].repeat(1, num_pred, 1, 1)
+    else:
+        raise NotImplementedError("Baseline {} not implemented".format(baseline))
+
+
+# Train
+def val(cfg):
+    assert cfg.split in ["val", "test"], "split must be in [val, test]"
+    dataloader = get_dataloader(cfg, cfg.split, load_audio=False, load_video=False, load_3dmm=False, load_ref=False)
+
+    for i, baseline in enumerate(baselines):
+
+        listener_emotion_list = []
+        listener_emotion_GT_list = []
+        speaker_emotion_list = []
+
+        for batch_idx, (_, _, speaker_emotion, _, _, listener_emotion, _, _) in enumerate(tqdm(dataloader)):
+            prediction = get_baseline(cfg, baseline, num_pred=10, speaker_emotion=speaker_emotion, listener_emotion=listener_emotion)
+
+            listener_emotion_list.append(prediction)
+            listener_emotion_GT_list.append(listener_emotion)
+            speaker_emotion_list.append(speaker_emotion)
+
+        all_pred_listener_emotion = torch.cat(listener_emotion_list, dim = 0)
+        all_speaker_emotion = torch.cat(speaker_emotion_list, dim = 0)
+        all_listener_emotion = torch.cat(listener_emotion_GT_list, dim = 0)
+
+        p = 64
+        assert all_speaker_emotion.shape[0] == all_pred_listener_emotion.shape[0], "Number of predictions and number of speaker emotions must match ({} vs. {})".format(all_pred_listener_emotion.shape[0], all_speaker_emotion.shape[0])
+        #print("-----------------Evaluating Metric-----------------")
+        np.seterr(divide='ignore', invalid='ignore')
+        FRC = compute_FRC_mp(cfg, all_pred_listener_emotion, all_listener_emotion, p=p, val_test=cfg.split)
+        FRD = compute_FRD_mp(cfg, all_pred_listener_emotion, all_listener_emotion, p=p, val_test=cfg.split)
+        FRDvs = compute_FRDvs(all_pred_listener_emotion)
+        FRVar  = compute_FRVar(all_pred_listener_emotion)
+        smse  = compute_s_mse(all_pred_listener_emotion)
+        TLCC = compute_TLCC_mp(all_pred_listener_emotion, all_speaker_emotion, p=p)
+
+        # print all results in one line
+        print("[{}/{}] Baseline: {}, FRC: {}, FRD: {}, FRDvs: {}, FRVar: {}, smse: {}, TLCC: {}".format(i+1, 
+                                                                                              len(baselines), 
+                                                                                              baseline, 
+                                                                                              FRC,
+                                                                                              FRD, 
+                                                                                              FRDvs, 
+                                                                                              FRVar, 
+                                                                                              smse,
+                                                                                              TLCC))
+
+        # latex friendly. FRC, FRD, TLCC with 2 decimals, FRDvs, FRVar, smse with 4 decimals. Split by columns in a table
+        print("B\\_{} & {:.2f} & {:.2f} & {:.4f} & {:.4f} & {:.4f} & - & {:.2f} \\\\".format(baseline, FRC, FRD, smse, FRVar, FRDvs, TLCC))
+
+
+def main():
+    args = parse_args()
+    val(args)
+
+
+# ---------------------------------------------------------------------------------
+
+
+if __name__=="__main__":
+    main()
+

--- a/test.py
+++ b/test.py
@@ -7,17 +7,18 @@ import torch.optim as optim
 import argparse
 from tqdm import tqdm
 import logging
-from dataset import TestDataset
+from dataset import ReactionDataset
 from model import TransformerVAE
 from utils import AverageMeter
 from render import Render
 from model.losses import VAELoss
 from metric import *
+from dataset import get_dataloader
 
 def parse_arg():
     parser = argparse.ArgumentParser(description='PyTorch Training')
     # Param
-    parser.add_argument('--dataset-path', default="/home/luocheng/Datasets/S-L", type=str, help="dataset path")
+    parser.add_argument('--dataset-path', default="./data", type=str, help="dataset path")
     parser.add_argument('--resume', default="", type=str, help="checkpoint path")
     parser.add_argument('-b', '--batch-size', default=4, type=int, metavar='N', help='mini-batch size (default: 4)')
     parser.add_argument('-j', '--num_workers', default=8, type=int, metavar='N',
@@ -39,12 +40,6 @@ def parse_arg():
     args = parser.parse_args()
     return args
 
-def get_dataloader(conf):
-    print('==> Preparing data...')
-    test_data = TestDataset(conf.dataset_path, img_size = conf.img_size, crop_size = conf.crop_size, clip_length = conf.seq_len)
-    test_loader = DataLoader(dataset=test_data, batch_size=conf.batch_size, shuffle=False, num_workers=conf.num_workers)
-    return test_loader, len(test_data)
-
 
 
 # Train
@@ -58,7 +53,7 @@ def test(args, model, val_loader, criterion, render):
     speaker_emotion_list = []
     all_listener_emotion_list = []
 
-    for batch_idx, (speaker_video_clip, speaker_audio_clip, speaker_emotion, listener_video_clip, listener_emotion, listener_3dmm, listener_references) in enumerate(tqdm(val_loader)):
+    for batch_idx, (speaker_video_clip, speaker_audio_clip, speaker_emotion, listener_video_clip, _, listener_emotion, listener_3dmm, listener_references) in enumerate(tqdm(val_loader)):
         if torch.cuda.is_available():
             speaker_video_clip, speaker_audio_clip, listener_emotion, listener_3dmm, listener_references = \
                 speaker_video_clip[:,:750].cuda(), speaker_audio_clip[:,:750].cuda(), listener_emotion[:,:750].cuda(), listener_3dmm[:,:750].cuda(), listener_references[:,:750].cuda()
@@ -89,7 +84,7 @@ def test(args, model, val_loader, criterion, render):
     print("-----------------Repeat 9 times-----------------")
     for i in range(9):
         listener_emotion_list = []
-        for batch_idx, (speaker_video_clip, speaker_audio_clip, _, _, _, _, _) in enumerate(tqdm(val_loader)):
+        for batch_idx, (speaker_video_clip, speaker_audio_clip, _, _, _, _, _, _) in enumerate(tqdm(val_loader)):
             if torch.cuda.is_available():
                 speaker_video_clip, speaker_audio_clip = \
                     speaker_video_clip[:,:750].cuda(), speaker_audio_clip[:,:750].cuda()
@@ -112,7 +107,7 @@ def test(args, model, val_loader, criterion, render):
 
 
 def main(args):
-    test_loader, test_data_num = get_dataloader(args)
+    test_loader = get_dataloader(args, "test")
     model = TransformerVAE(img_size = args.img_size, audio_dim = args.audio_dim, output_emotion_dim = args.emotion_dim, output_3dmm_dim = args._3dmm_dim, feature_dim = args.feature_dim, seq_len = args.seq_len, online = args.online, window_size = args.window_size, device = args.device)
     criterion = VAELoss(args.kl_p)
 

--- a/tool/matrix_split.py
+++ b/tool/matrix_split.py
@@ -6,7 +6,7 @@ import os
 
 def parse_arg():
     parser = argparse.ArgumentParser(description='PyTorch Training')
-    parser.add_argument('--dataset-path', default="/home/luocheng/Datasets/S-L", type=str, help="dataset path")
+    parser.add_argument('--dataset-path', default="./data", type=str, help="dataset path")
     parser.add_argument('--partition', default="val", type=str, help="dataset partition")
     args = parser.parse_args()
     return args
@@ -38,8 +38,6 @@ for index, row in val_path.iterrows():
         if path_val_item == path_data_index:
             index_list.append(index_2-1)
             flag = 1
-    if flag == 0:
-        print(path_t)
 
 l_m = len(index_list)
 new_matrix = np.zeros((l_m*2, l_m*2))

--- a/train.py
+++ b/train.py
@@ -111,8 +111,8 @@ def val(args, model, val_loader, criterion, render, epoch):
 def main(args):
     start_epoch = 0
     lowest_val_loss = 10000
-    train_loader = get_dataloader(args, "train")
-    val_loader = get_dataloader(args, "val")
+    train_loader = get_dataloader(args, "train", load_ref=False, load_video_l=False)
+    val_loader = get_dataloader(args, "val", load_video_l=False)
     model = TransformerVAE(img_size = args.img_size, audio_dim = args.audio_dim,  output_3dmm_dim = 58, output_emotion_dim = 25, feature_dim = args.feature_dim, seq_len = args.seq_len, online = args.online, window_size = args.window_size, device = args.device)
     criterion = VAELoss(args.kl_p)
 

--- a/val.py
+++ b/val.py
@@ -7,17 +7,18 @@ import torch.optim as optim
 import argparse
 from tqdm import tqdm
 import logging
-from dataset import ValDataset
+from dataset import ReactionDataset
 from model import TransformerVAE
 from utils import AverageMeter
 from render import Render
 from model.losses import VAELoss
 from metric import *
+from dataset import get_dataloader
 
 def parse_arg():
     parser = argparse.ArgumentParser(description='PyTorch Training')
     # Param
-    parser.add_argument('--dataset-path', default="/home/luocheng/Datasets/S-L", type=str, help="dataset path")
+    parser.add_argument('--dataset-path', default="./data", type=str, help="dataset path")
     parser.add_argument('--resume', default="", type=str, help="checkpoint path")
     parser.add_argument('-b', '--batch-size', default=4, type=int, metavar='N', help='mini-batch size (default: 4)')
     parser.add_argument('-j', '--num_workers', default=8, type=int, metavar='N',
@@ -39,13 +40,6 @@ def parse_arg():
     args = parser.parse_args()
     return args
 
-def get_dataloader(conf):
-    print('==> Preparing data...')
-    val_data = ValDataset(conf.dataset_path, img_size = conf.img_size, crop_size = conf.crop_size, clip_length = conf.seq_len)
-    val_loader = DataLoader(dataset=val_data, batch_size=conf.batch_size, shuffle=False, num_workers=conf.num_workers)
-    return val_loader, len(val_data)
-
-
 
 # Train
 def val(args, model, val_loader, criterion, render):
@@ -58,7 +52,7 @@ def val(args, model, val_loader, criterion, render):
     speaker_emotion_list = []
     all_listener_emotion_list = []
 
-    for batch_idx, (speaker_video_clip, speaker_audio_clip, speaker_emotion, listener_video_clip, listener_emotion, listener_3dmm, listener_references) in enumerate(tqdm(val_loader)):
+    for batch_idx, (speaker_video_clip, speaker_audio_clip, speaker_emotion, listener_video_clip, _, listener_emotion, listener_3dmm, listener_references) in enumerate(tqdm(val_loader)):
         if torch.cuda.is_available():
             speaker_video_clip, speaker_audio_clip, listener_emotion, listener_3dmm, listener_references = \
                 speaker_video_clip[:,:750].cuda(), speaker_audio_clip[:,:750].cuda(), listener_emotion[:,:750].cuda(), listener_3dmm[:,:750].cuda(), listener_references[:,:750].cuda()
@@ -89,7 +83,7 @@ def val(args, model, val_loader, criterion, render):
     print("-----------------Repeat 9 times-----------------")
     for i in range(9):
         listener_emotion_list = []
-        for batch_idx, (speaker_video_clip, speaker_audio_clip, _, _, _, _, _) in enumerate(tqdm(val_loader)):
+        for batch_idx, (speaker_video_clip, speaker_audio_clip, _, _, _, _, _, _) in enumerate(tqdm(val_loader)):
             if torch.cuda.is_available():
                 speaker_video_clip, speaker_audio_clip = \
                     speaker_video_clip[:,:750].cuda(), speaker_audio_clip[:,:750].cuda()
@@ -112,7 +106,7 @@ def val(args, model, val_loader, criterion, render):
 
 
 def main(args):
-    val_loader, val_data_num = get_dataloader(args)
+    val_loader = get_dataloader(args, "val")
     model = TransformerVAE(img_size = args.img_size, audio_dim = args.audio_dim, output_emotion_dim = args.emotion_dim, output_3dmm_dim = args._3dmm_dim, feature_dim = args.feature_dim, seq_len = args.seq_len, online = args.online, window_size = args.window_size, device = args.device)
     criterion = VAELoss(args.kl_p)
 


### PR DESCRIPTION
1. The three datasets that were kept for train/val/test purposes are now unified. All of them return now the same information (everything, basically), but such information might be loaded or not (depending on the initialization arguments). For example, load_video_s=False to avoid loading image data from the speaker, in case an audio- or emotion-based baseline is being developed. This helps accelerating the training/evaluation when the model doesn't need all the data.
2. A script "run_baselines" is included to benchmark the 4 naive baselines, and the ground truth. 
3. Validation and test evaluation are now unified in a single script (evaluate.py), and the split can be selected from CLI.

README is updated accordingly.

See email for further details.